### PR TITLE
Add public visibility to user_login method

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -93,7 +93,7 @@ class auth_plugin_dev extends auth_plugin_base {
      *
      * @return bool Authentication success or failure.
      */
-    function user_login($username, $password) {
+    public function user_login($username, $password) {
         return false;
     }
 }


### PR DESCRIPTION
Implicit public visibility on methods is deprecated in PHP 8.2 and will become an error in future PHP versions.