### PR TITLE
Use PARAM_URL for logout URL setting

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -30,6 +30,6 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('auth_dev/enablelogouturl', get_string('config_enablelogouturl', 'auth_dev'),
         get_string('config_enablelogouturl_description', 'auth_dev'), 0));
     $settings->add(new admin_setting_configtext('auth_dev/logouturl',
-        get_string('config_logouturl', 'auth_dev'), '', '', PARAM_RAW_TRIMMED));
+        get_string('config_logouturl', 'auth_dev'), '', '', PARAM_URL));
 
 }


### PR DESCRIPTION
Replaced PARAM_RAW_TRIMMED with PARAM_URL to properly validate the redirect URL and meet Moodle coding standards.