### PR TITLE
Release for Moodle 3.9 to 5.1 compatibility

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022090500;
-$plugin->requires  = 2013101800;
+$plugin->version   = 2026033100;
+$plugin->requires  = 2020061500;
 $plugin->component = 'auth_dev';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.3';
+$plugin->release = '2.3.1';


### PR DESCRIPTION
Updated the minimum required Moodle version to 3.9.
Bumped plugin version and release to reflect compatibility fixes for Moodle 3.9 through 5.1 and PHP 7.4 through 8.3.